### PR TITLE
fix: normalize MCP inputSchema before passing to OpenAI

### DIFF
--- a/wake_ai/core/openai.py
+++ b/wake_ai/core/openai.py
@@ -40,6 +40,15 @@ class OpenAIResponse(NamedTuple):
     status: Literal["running", "terminating_on_max_cost", "succeeded", "terminated", "errored"]
 
 
+def _normalize_mcp_schema(schema: Any) -> dict[str, Any]:
+    """Ensure MCP inputSchema includes 'properties' — required by OpenAI for object schemas."""
+    if not isinstance(schema, dict) or schema.get("type") != "object":
+        return {"type": "object", "properties": {}}
+    if "properties" not in schema:
+        return {**schema, "properties": {}}
+    return schema
+
+
 def _compute_backoff_time(retry: int) -> float:
     # base time is 20 seconds, exponential growth; 10% jitter
     # retry starts at 0
@@ -333,7 +342,7 @@ class OpenAISession(SessionABC):
 
                     tools.append(FunctionToolParam(
                         name=f"{server_name}.{tool.name}",
-                        parameters=tool.inputSchema,
+                        parameters=_normalize_mcp_schema(tool.inputSchema),
                         description=tool.description,
                         type="function",
                         strict=False,


### PR DESCRIPTION
## Summary
OpenAI requires `properties` to be present on all `"type": "object"` function schemas.
Many MCP servers omit `properties` for tools without parameters — valid per MCP spec,
but OpenAI rejects them with `invalid_function_parameters`.

Adds `_normalize_mcp_schema()` to ensure `properties: {}` is present before registration.