### PR TITLE
fix: adapt audit validators and examples to new WorkflowStep API

### DIFF
--- a/docs/examples/dynamic_workflow.py
+++ b/docs/examples/dynamic_workflow.py
@@ -7,86 +7,74 @@ This workflow:
 """
 
 import re
-from typing import Dict, Any, List
 import rich_click as click
-from wake_ai import AIWorkflow, WorkflowStep, workflow
-from wake_ai.core.claude import ClaudeCodeResponse
+from wake_ai import AIWorkflow, DynamicWorkflowStep, workflow
 
 
 class DynamicAnalysisWorkflow(AIWorkflow):
     """Workflow that dynamically creates steps based on initial analysis."""
-    
+
     def __init__(self, **kwargs):
         """Initialize the workflow."""
-        pass
-    
+        super().__init__(**kwargs)
+
     @workflow.command("dynamic-analysis")
     @click.option("--target-dir", "-d", type=str, default=".", help="Directory to analyze")
     def cli(self, target_dir):
         """Run dynamic analysis workflow."""
         self.target_dir = target_dir
-    
+
     def _setup_steps(self):
         """Setup initial workflow steps."""
         # Step 1: Find all Python classes
-        self.add_step(
+        find_step = self.add_step(
             name="find_classes",
             prompt_template="""Find all Python classes in {{target_dir}}.
-            
-For each class found, output:
-- File path
-- Class name  
-- Line number where class is defined
 
-Format your response as a numbered list like:
-1. `path/to/file.py` - ClassName (line 42)
-2. `another/file.py` - AnotherClass (line 15)
+For each class found, write one line per class to {{working_dir}}/classes.txt:
+path/to/file.py:ClassName:42
 """,
-            allowed_tools=None,  # Use default tools
+            model="claude-opus-4-5",
             max_cost=3.0
         )
-        
-        # Register dynamic step generator
-        self.add_dynamic_steps(
+
+        # Dynamic step: generate one investigation step per discovered class
+        self.add_dynamic_step(
             name="investigate_classes",
-            generator=self._generate_class_investigation_steps,
-            after_step="find_classes"
+            handler=self._investigate_classes_handler,
+            requires=[find_step],
         )
-        
+
         # Final step: Summarize findings
         self.add_step(
             name="summarize",
-            prompt_template="""Create a summary of all the classes you've analyzed.
+            prompt_template="""Create a summary report in {{working_dir}}/summary.md of all class analyses found in {{working_dir}}.
 
 Include:
 - Total number of classes analyzed
 - Key patterns or observations
 - Any potential issues or improvements
-
-{% for step_name in _completed_steps %}
-{% if step_name.startswith('investigate_class_') %}
-## {{ step_name }}
-{{ _get_output(step_name) }}
-
-{% endif %}
-{% endfor %}
 """,
+            model="claude-opus-4-5",
             max_cost=2.0
         )
-    
-    def _generate_class_investigation_steps(self, response: ClaudeCodeResponse, 
-                                          context: Dict[str, Any]) -> List[WorkflowStep]:
-        """Generate investigation steps for each class found."""
-        # Parse classes from the response
-        content = response.content
-        
-        # Pattern to match our expected format: 1. `path/file.py` - ClassName (line N)
-        pattern = r'\d+\.\s*`([^`]+)`\s*-\s*(\w+)\s*\(line\s*(\d+)\)'
-        matches = re.findall(pattern, content)
-        
-        steps = []
-        for i, (file_path, class_name, line_num) in enumerate(matches[:5]):  # Limit to 5 classes
-            steps.append(WorkflowStep(
+
+    async def _investigate_classes_handler(self, _step: DynamicWorkflowStep) -> None:
+        """Spawn one WorkflowStep per class found by find_classes."""
+        classes_file = self.working_dir / "classes.txt"
+        if not classes_file.exists():
+            return
+
+        # Pattern: path/to/file.py:ClassName:42
+        pattern = re.compile(r'^(.+):(\w+):(\d+)$')
+        matches = []
+        for line in classes_file.read_text().splitlines():
+            m = pattern.match(line.strip())
+            if m:
+                matches.append(m.groups())
+
+        for i, (file_path, class_name, line_num) in enumerate(matches[:5]):  # Limit to 5
+            self.add_step(
                 name=f"investigate_class_{i}_{class_name.lower()}",
                 prompt_template=f"""Analyze the class {class_name} in {file_path} (around line {line_num}).
 
@@ -96,56 +84,16 @@ Provide:
 3. Any design patterns used
 4. Potential improvements or issues
 
-Keep your analysis concise (3-5 sentences per section).""",
-                allowed_tools=None,  # Use default tools
+Write your analysis to {{{{working_dir}}}}/{class_name.lower()}_analysis.md""",
+                model="claude-opus-4-5",
                 max_cost=1.5,
-                continue_session=False  # Each investigation gets fresh context
-            ))
-        
-        if not steps:
-            # No classes found, add a placeholder step
-            steps.append(WorkflowStep(
-                name="no_classes_found",
-                prompt_template="No Python classes were found in the target directory. Please verify the directory contains Python files.",
-                max_cost=0.1
-            ))
-        
-        return steps
-    
-    def _custom_context_update(self, step_name: str, response: ClaudeCodeResponse):
-        """Store outputs for the summary step."""
-        # Make completed steps and outputs available to templates
-        if not hasattr(self.state.context, '_completed_steps'):
-            self.state.context['_completed_steps'] = []
-            self.state.context['_outputs'] = {}
-        
-        self.state.context['_completed_steps'].append(step_name)
-        self.state.context['_outputs'][step_name] = response.content
-        
-        # Helper function for templates
-        self.state.context['_get_output'] = lambda name: self.state.context['_outputs'].get(name, '')
+            )
 
 
 if __name__ == "__main__":
     # Example usage
-    workflow = DynamicAnalysisWorkflow()
-    
-    # Configure via CLI method
-    workflow.cli(target_dir="wake_ai/core")
-    
-    # Add initial context
-    workflow.add_context("target_dir", "wake_ai/core")
-    
-    # Execute workflow
-    results, ai_result = workflow.execute()
-    
-    print("\n=== Workflow Results ===")
-    print(f"Total steps executed: {len(workflow.state.completed_steps)}")
-    print(f"Dynamic steps added: {len([s for s in workflow.state.completed_steps if 'investigate_class_' in s])}")
-    
-    if ai_result.success:
-        print("\nWorkflow completed successfully!")
-        print(f"\nSummary:\n{results.get('summarize_output', 'No summary available')}")
-    else:
-        print("\nWorkflow failed!")
-        print(f"Errors: {ai_result.error}")
+    wf = DynamicAnalysisWorkflow()
+    wf.add_context("target_dir", "wake_ai/core")
+
+    result = wf.run()
+    print(f"\nWorkflow status: {result.status}")

--- a/docs/examples/hooks_workflow.py
+++ b/docs/examples/hooks_workflow.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import json
 import rich_click as click
 
-from wake_ai.core import AIWorkflow, WorkflowStep, ClaudeCodeResponse
+from wake_ai.core import AIWorkflow, WorkflowStep
 from wake_ai import workflow
 from wake_ai.results import SimpleResult
 from wake_ai.utils import get_logger
@@ -70,7 +70,7 @@ class HookExampleWorkflow(AIWorkflow):
         """Called before each step execution."""
         logger.info(f"[PRE-STEP] Starting step '{step.name}'")
         logger.info(f"  - Max cost limit: ${step.max_cost or 'unlimited'}")
-        logger.info(f"  - Allowed tools: {step.allowed_tools or 'default'}")
+        logger.info(f"  - Max cost limit: ${step.max_cost or 'unlimited'}")
 
         # Track step start time
         self.step_start_times[step.name] = datetime.now()
@@ -80,16 +80,17 @@ class HookExampleWorkflow(AIWorkflow):
             # Calculate total cost from previous steps
             total_cost = sum(self.step_costs.values())
 
-            # Add dynamic context directly to self.state.context
-            self.state.context["report_timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            self.state.context["total_cost"] = total_cost
+            # Add dynamic context directly to self.context
+            self.context["report_timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self.context["total_cost"] = total_cost
             logger.info(f"  - Added report context: timestamp and total cost ${total_cost:.4f}")
 
         # Always add step counter
-        self.state.context["step_number"] = self.state.current_step + 1
-        self.state.context["total_steps"] = len(self.steps)
+        completed = sum(1 for s in self.steps if s.status == "completed")
+        self.context["step_number"] = completed + 1
+        self.context["total_steps"] = len(self.steps)
 
-    def _post_step_hook(self, step: WorkflowStep, response: ClaudeCodeResponse) -> None:
+    def _post_step_hook(self, step: WorkflowStep) -> None:
         """Called after each step execution."""
         # Calculate step duration
         if step.name in self.step_start_times:
@@ -98,18 +99,17 @@ class HookExampleWorkflow(AIWorkflow):
             duration = 0
 
         # Track step cost
-        self.step_costs[step.name] = response.cost
+        self.step_costs[step.name] = step.cost
 
         logger.info(f"[POST-STEP] Completed step '{step.name}'")
         logger.info(f"  - Duration: {duration:.2f} seconds")
-        logger.info(f"  - Cost: ${response.cost:.4f}")
-        logger.info(f"  - Success: {response.success}")
-        logger.info(f"  - Turns: {response.num_turns}")
+        logger.info(f"  - Cost: ${step.cost:.4f}")
+        logger.info(f"  - Status: {step.status}")
 
         # Save metrics to file
-        self._save_step_metrics(step, response, duration)
+        self._save_step_metrics(step, duration)
 
-    def _save_step_metrics(self, step: WorkflowStep, response: ClaudeCodeResponse, duration: float) -> None:
+    def _save_step_metrics(self, step: WorkflowStep, duration: float) -> None:
         """Save step metrics to a JSON file."""
         metrics_file = self.working_dir / "metrics.json"
 
@@ -118,10 +118,9 @@ class HookExampleWorkflow(AIWorkflow):
             "step": step.name,
             "timestamp": datetime.now().isoformat(),
             "duration_seconds": duration,
-            "cost": response.cost,
-            "success": response.success,
-            "turns": response.num_turns,
-            "session_id": response.session_id or "N/A"
+            "cost": step.cost,
+            "status": step.status,
+            "session_id": step.session.session_id or "N/A"
         }
 
         # Load existing metrics or create new list

--- a/prompts/wake-ai-flow-generation.md
+++ b/prompts/wake-ai-flow-generation.md
@@ -203,37 +203,41 @@ self.add_extraction_step(
 
 ### b. **Dynamic Step Generation**:
 ```python
-def _generate_remediation_steps(self, response: ClaudeCodeResponse, context: Dict[str, Any]) -> List[WorkflowStep]:
-    """Generate steps based on findings."""
-    steps = []
+# In _setup_steps():
+analyze_step = self.add_step(name="analyze", ...)
+self.add_dynamic_step(
+    name="remediation_generator",
+    handler=self._generate_remediation_steps,
+    requires=[analyze_step],
+)
 
-    vulnerabilities = context.get("vulnerabilities", [])
+async def _generate_remediation_steps(self, _step: DynamicWorkflowStep) -> None:
+    """Spawn remediation steps based on findings written by 'analyze'."""
+    import yaml
+    vuln_file = self.working_dir / "vulnerabilities.yaml"
+    if not vuln_file.exists():
+        return
+
+    with open(vuln_file) as f:
+        vulnerabilities = yaml.safe_load(f) or []
+
     for i, vuln in enumerate(vulnerabilities):
-        steps.append(WorkflowStep(
+        self.add_step(
             name=f"fix_vulnerability_{i}",
             prompt_template=f"Fix the {vuln['type']} vulnerability in {vuln['contract']}",
-            allowed_tools=["Read", "Edit", "Write"],
-            max_cost=3.0
-        ))
-
-    return steps
-
-# In _setup_steps():
-self.add_dynamic_steps(
-    name="remediation_generator",
-    generator=self._generate_remediation_steps,
-    after_step="analyze"
-)
+            model=...,
+            max_cost=3.0,
+        )
 ```
 
 ## 5. **Implement Validators with Prompt Alignment**
 
 ### Critical Rule: Validators Must Match Prompts Exactly
 
-Create validation functions that return `(success: bool, errors: List[str])` and **exactly match what you asked for in the prompt**:
+Create validation functions that return `list[str]` (empty = success) and **exactly match what you asked for in the prompt**:
 
 ```python
-def _validate_analysis(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+def _validate_analysis(self, _step: WorkflowStep) -> list[str]:
     """Validate analysis step output - MUST match prompt requirements exactly."""
     errors = []
 
@@ -244,7 +248,7 @@ def _validate_analysis(self, response: ClaudeCodeResponse) -> Tuple[bool, List[s
             f"Required file 'analysis_results.yaml' not created at {results_file}. "
             "The prompt asks you to create this file with vulnerability findings."
         )
-        return (False, errors)
+        return errors
 
     # Validate YAML structure (match exact structure from prompt)
     try:
@@ -282,7 +286,7 @@ def _validate_analysis(self, response: ClaudeCodeResponse) -> Tuple[bool, List[s
     except Exception as e:
         errors.append(f"Invalid YAML format: {str(e)}. Check the YAML example in the prompt.")
 
-    return (len(errors) == 0, errors)
+    return errors
 ```
 
 ### Validation Best Practices
@@ -461,7 +465,7 @@ Previous findings: {{initialize_output}}
 
 3. **Write Validator That Checks Each Requirement**:
    ```python
-   def _validate_results(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+   def _validate_results(self, _step: WorkflowStep) -> list[str]:
        errors = []
 
        # Check exact filename from prompt
@@ -471,7 +475,7 @@ Previous findings: {{initialize_output}}
                f"File 'results.yaml' not created at {results_file}. "
                "The prompt asks you to create this exact file."
            )
-           return (False, errors)
+           return errors
 
        try:
            with open(results_file) as f:
@@ -515,7 +519,7 @@ Previous findings: {{initialize_output}}
        except yaml.YAMLError as e:
            errors.append(f"Invalid YAML: {e}. Check prompt example for correct format.")
 
-       return (len(errors) == 0, errors)
+       return errors
    ```
 
 ### Validation Alignment Checklist
@@ -674,7 +678,7 @@ from pydantic import BaseModel
 
 from wake_ai import AIWorkflow, WorkflowStep
 from wake_ai.results import AIResult
-from wake_ai.core.claude import ClaudeCodeResponse
+
 
 
 class VulnerabilityInfo(BaseModel):
@@ -857,21 +861,22 @@ vulnerabilities:
 
 Include all vulnerabilities found, ordered by severity (high to low)."""
 
-    def _validate_scan(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+    def _validate_scan(self, _step: WorkflowStep) -> list[str]:
         """Validate initial scan completed successfully."""
-        # Basic validation - just check response has content
-        if not response.content:
-            return (False, ["Scan produced no output"])
-        return (True, [])
+        # Check that the scan produced an output file
+        scan_file = self.working_dir / "scan_results.yaml"
+        if not scan_file.exists():
+            return ["scan_results.yaml not created by scan step"]
+        return []
 
-    def _validate_report(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+    def _validate_report(self, _step: WorkflowStep) -> list[str]:
         """Validate final report generation."""
         errors = []
         report_file = self.working_dir / "reentrancy_report.yaml"
 
         if not report_file.exists():
             errors.append("reentrancy_report.yaml not created")
-            return (False, errors)
+            return errors
 
         try:
             import yaml
@@ -884,7 +889,7 @@ Include all vulnerabilities found, ordered by severity (high to low)."""
         except Exception as e:
             errors.append(f"Invalid YAML in report: {str(e)}")
 
-        return (len(errors) == 0, errors)
+        return errors
 
     @workflow.command("reentrancy")
     @click.option(
@@ -1043,7 +1048,7 @@ from typing import Dict, Any, List, Tuple
 import rich_click as click
 
 from wake_ai import AIWorkflow
-from wake_ai.core.claude import ClaudeCodeResponse
+
 
 
 class UpgradeabilityAudit(AIWorkflow):
@@ -1061,10 +1066,10 @@ class UpgradeabilityAudit(AIWorkflow):
 
     def _setup_steps(self):
         # Step 1: Analyze proxy pattern
-        self.add_step(
+        proxy_step = self.add_step(
             name="analyze_proxy",
             prompt_template=self.prompts["analyze_proxy"],
-            allowed_tools=["Read", "Grep", "Task"],
+            model=...,
             max_cost=5.0,
             validator=self._validate_proxy_analysis
         )
@@ -1073,37 +1078,37 @@ class UpgradeabilityAudit(AIWorkflow):
         self.add_step(
             name="storage_check",
             prompt_template=self.prompts["storage_check"],
-            allowed_tools=["Read", "Bash(wake print storage-layout:*)"],
-            continue_session=True,
-            max_cost=3.0
+            model=...,
+            max_cost=3.0,
+            requires=[proxy_step],
         )
 
         # Step 3: Security analysis
-        self.add_step(
+        audit_step = self.add_step(
             name="security_audit",
             prompt_template=self.prompts["security_audit"],
-            allowed_tools=["Read", "Write", "Task"],
+            model=...,
             max_cost=10.0,
             validator=self._validate_security_audit
         )
 
         # Dynamic steps based on findings
-        self.add_dynamic_steps(
+        self.add_dynamic_step(
             name="issue_remediation",
-            generator=self._generate_fix_steps,
-            after_step="security_audit"
+            handler=self._generate_fix_steps,
+            requires=[audit_step],
         )
 
-    def _validate_proxy_analysis(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+    def _validate_proxy_analysis(self, _step: WorkflowStep) -> list[str]:
         errors = []
         analysis_file = self.working_dir / "proxy_analysis.yaml"
 
         if not analysis_file.exists():
             errors.append("proxy_analysis.yaml not created")
 
-        return (len(errors) == 0, errors)
+        return errors
 
-    def _validate_security_audit(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+    def _validate_security_audit(self, _step: WorkflowStep) -> list[str]:
         errors = []
 
         required_files = ["security_findings.yaml", "audit_report.md"]
@@ -1111,24 +1116,23 @@ class UpgradeabilityAudit(AIWorkflow):
             if not (self.working_dir / file).exists():
                 errors.append(f"Required file {file} not created")
 
-        return (len(errors) == 0, errors)
+        return errors
 
-    def _generate_fix_steps(self, response: ClaudeCodeResponse, context: Dict[str, Any]) -> List[WorkflowStep]:
+    async def _generate_fix_steps(self, _step: DynamicWorkflowStep) -> None:
         # Parse findings and generate remediation steps
         import yaml
 
         findings_file = self.working_dir / "security_findings.yaml"
         if not findings_file.exists():
-            return []
+            return
 
         with open(findings_file) as f:
             findings = yaml.safe_load(f)
 
-        steps = []
         critical_issues = [f for f in findings.get("issues", []) if f["severity"] == "critical"]
 
         for i, issue in enumerate(critical_issues[:3]):  # Limit to 3 critical fixes
-            steps.append(WorkflowStep(
+            self.add_step(
                 name=f"fix_critical_{i}",
                 prompt_template=f"""Fix the critical issue: {issue['title']}
 
@@ -1136,11 +1140,9 @@ Issue description: {issue['description']}
 Location: {issue['location']}
 
 Generate a patch file that addresses this issue.""",
-                allowed_tools=["Read", "Write", "Edit"],
-                max_cost=3.0
-            ))
-
-        return steps
+                model=...,
+                max_cost=3.0,
+            )
 
     @workflow.command("upgradeability-audit")
     @click.option(

--- a/wake_ai/flows/audit/workflow.py
+++ b/wake_ai/flows/audit/workflow.py
@@ -7,7 +7,7 @@ import yaml
 import rich_click as click
 
 from wake_ai import workflow
-from wake_ai.core.flow import AIWorkflow, ClaudeCodeResponse, AIResult
+from wake_ai.core.flow import AIWorkflow, AIResult, WorkflowStep
 
 # Valid detection types for audit findings
 VALID_DETECTION_TYPES = [
@@ -127,7 +127,7 @@ class AuditWorkflow(AIWorkflow):
             max_retry_cost=5.0
         )
 
-    def _validate_initialize(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+    def _validate_initialize(self, _step: WorkflowStep) -> list[str]:
         """Validate initialization step - check if wake init was successful."""
         errors = []
 
@@ -139,9 +139,9 @@ class AuditWorkflow(AIWorkflow):
             if not parent_wake_config.exists():
                 errors.append("wake.toml not found - wake init may have failed")
 
-        return (len(errors) == 0, errors)
+        return errors
 
-    def _validate_analyze_and_plan(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+    def _validate_analyze_and_plan(self, _step: WorkflowStep) -> list[str]:
         """Validate analyze and plan step - check for required files and YAML structure."""
         errors = []
 
@@ -205,9 +205,9 @@ class AuditWorkflow(AIWorkflow):
             except Exception as e:
                 errors.append(f"Error validating {plan_file} structure: {str(e)}")
 
-        return (len(errors) == 0, errors)
+        return errors
 
-    def _validate_manual_review(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+    def _validate_manual_review(self, _step: WorkflowStep) -> list[str]:
         """Validate manual review step - check for updated plan and issue files."""
         errors = []
 
@@ -290,9 +290,9 @@ class AuditWorkflow(AIWorkflow):
             except Exception as e:
                 errors.append(f"Error validating updated {plan_file}: {str(e)}")
 
-        return (len(errors) == 0, errors)
+        return errors
 
-    def _validate_executive_summary(self, response: ClaudeCodeResponse) -> Tuple[bool, List[str]]:
+    def _validate_executive_summary(self, _step: WorkflowStep) -> list[str]:
         """Validate executive summary step."""
         errors = []
 
@@ -332,7 +332,7 @@ class AuditWorkflow(AIWorkflow):
             if len(content) < 500:
                 errors.append(f"Executive summary in {summary_file} is too short (minimum 500 characters)")
 
-        return (len(errors) == 0, errors)
+        return errors
 
     def _build_prompt(self, step_name: str) -> str:
         """Build prompt with context variables."""


### PR DESCRIPTION
## Summary

- Replaced `ClaudeCodeResponse` with `WorkflowStep` in all validator signatures
- Validators now return `list[str]` (empty = success) instead of `Tuple[bool, List[str]]`
- Updated dynamic step API: `add_dynamic_steps(generator=...)` → `add_dynamic_step(handler=...)` with async handler
- `self.state.context` → `self.context` in hooks
- Synced docs examples and flow-generation prompt to match

## Changes

| File | What changed |
|------|-------------|
| `wake_ai/flows/audit/workflow.py` | Fix 4 validators to new API |
| `docs/examples/dynamic_workflow.py` | Update to `DynamicWorkflowStep` + async handler |
| `docs/examples/hooks_workflow.py` | Update hook signatures and context access |
| `prompts/wake-ai-flow-generation.md` | Sync all code examples to new API |
